### PR TITLE
Minor changes to enable obscura installation and execution from scratch from a third-party computer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/pytoda"]
 	path = src/pytoda
-	url = git@github.com:davidrudlstorfer/pytoda.git
+	url = https://github.com/davidrudlstorfer/pytoda.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["dependencies"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["obscura"]
+include = ["obscura*"]
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.in"] }


### PR DESCRIPTION
- Change in .gitmodules to avoid SSH-authentification issues → HTTPS
- Change in the pyproject.toml file (obscura → obscura*) to ensure that nested modules (e.g., obscura.core.rendering) are included during the build process
