### PR TITLE
Update Blender to 5.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/linux,macos,python,windows,synology,visualstudiocode
+
+#Render folder from local setup
+render/

--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ git submodule --quiet foreach --recursive pip install -e .
 
 5. Install all Obscura requirements (latest versions):
 ```
-pip install -e .
-```
-or install the pinned versions with:
-```
 pip install -e ."[safe]"
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,9 +35,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Blender installation
 WORKDIR /opt
-ARG BLENDER_VERSION=4.4.3
-ARG BLENDER_MAJOR=4.4
-RUN wget https://ftp.halifax.rwth-aachen.de/blender/release/Blender${BLENDER_MAJOR}/blender-${BLENDER_VERSION}-linux-x64.tar.xz && \
+ARG BLENDER_VERSION=5.2.0
+ARG BLENDER_MAJOR=5.2
+RUN wget https://download.blender.org/release/Blender${BLENDER_MAJOR}/blender-${BLENDER_VERSION}-linux-x64.tar.xz && \
     mkdir -p /opt/blender && \
     tar -xvf blender-${BLENDER_VERSION}-linux-x64.tar.xz --strip-components=1 -C /opt/blender && \
     rm blender-${BLENDER_VERSION}-linux-x64.tar.xz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ license = {file = "LICENSE.md"}
 keywords = ["Skeleton", "Documentation", "CICD", "Testing", "Pre-Commit"]
 classifiers = ["Programming Language :: Python :: 3.13"]
 
-requires-python = "==3.11.*"
-dynamic = ["dependencies"]
+requires-python = ">=3.11"
+dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/obscura/core/rendering/object_settings.py
+++ b/src/obscura/core/rendering/object_settings.py
@@ -30,5 +30,5 @@ def compute_geometry(mesh_obj: bpy.types.Object) -> tuple[np.ndarray, float]:
     """Compute bounding box center and maximum extent."""
     bbox = np.asarray(mesh_obj.bound_box)
     center = bbox.mean(axis=0)
-    max_extent = bbox.ptp(axis=0).max()
+    max_extent = np.ptp(bbox, axis=0).max()
     return center, max_extent

--- a/src/obscura/core/utilities.py
+++ b/src/obscura/core/utilities.py
@@ -66,7 +66,7 @@ class RunManager:
             ),
             "w",
         ) as file:
-            yaml.dump(self.config.toDict(), file)
+            yaml.dump(self.config.model_dump(), file)
 
         log.info("     ... done.")
         log.info("")

--- a/tests/obscura/core/test_utilities.py
+++ b/tests/obscura/core/test_utilities.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from munch import munchify
 
 from obscura.core.utilities import RunManager
 
@@ -47,31 +46,28 @@ def test_write_config(tmp_path: Path) -> None:
     Args:
         tmp_path (Path): Temporary from pytest.
     """
-    mock_config = munchify(
-        {
-            "general": {
-                "output_directory": str(tmp_path),
-                "sim_name": "sim_name",
-            }
+    config_dict = {
+        "general": {
+            "output_directory": str(tmp_path),
+            "sim_name": "sim_name",
         }
-    )
+    }
+    mock_config = MagicMock()
+    mock_config.general.output_directory = str(tmp_path)
+    mock_config.general.sim_name = "sim_name"
+    mock_config.model_dump.return_value = config_dict
 
     run_manager = RunManager(mock_config)
 
     run_manager.write_config()
 
     with open(os.path.join(tmp_path, "sim_name", "config.yaml"), "r") as file:
-        assert file.read() == yaml.dump(mock_config.toDict())
+        assert file.read() == yaml.dump(config_dict)
 
     # check invalid input parameter combination
-    mock_config = munchify(
-        {
-            "general": {
-                "output_directory": None,
-                "sim_name": None,
-            }
-        }
-    )
+    mock_config = MagicMock()
+    mock_config.general.output_directory = None
+    mock_config.general.sim_name = None
     run_manager = RunManager(mock_config)
     with pytest.raises(
         ValueError, match="Output directory and sim name must be provided for output!"


### PR DESCRIPTION
Updates the Blender version to 5.1.0 and fixes the NumPy/Python compatibility issues this surfaced in both the Docker and local/conda install paths.

Surfacing problem: pip install -e . can still resolve an old, NumPy-1.x-compiled bpy that crashes on import — this is a known upstream issue (no bpy wheel for Python 3.11 is yet built against NumPy 2.x's ABI: [blender/blender#134550](https://projects.blender.org/blender/blender/issues/134550)). Use pip install -e ."[safe]" for a working local install until that's resolved upstream.

Follow-up: once the README PR is merged, the README should be updated to recommend pip install -e ."[safe]" as the primary local install command as long as the upstream issue exists.